### PR TITLE
Active states on numbered buttons

### DIFF
--- a/src/NumOfQBtn.jsx
+++ b/src/NumOfQBtn.jsx
@@ -1,14 +1,19 @@
 const NumOfQBtn = (props) => {
-  const { number, setQuestionCount } = props;
+  const { number, setQuestionCount, isActive } = props;
   return (
-    <button
-      onClick={(e) => {
-        setQuestionCount(parseInt(e.target.textContent));
-      }}
-      className="w-full p-2 grid place-items-center bg-gray-100 hover:bg-indigo-500 hover:text-white duration-200 rounded-sm"
+    <label
+      className="w-full p-2 grid place-items-center bg-gray-100 hover:bg-indigo-500 hover:text-white duration-200 rounded-sm cursor-pointer has-[:checked]:bg-indigo-500 has-[:checked]:text-white"
     >
       {number}
-    </button>
+      <input 
+        type="radio"
+        className="hidden"
+        name="questionCount"
+        value={number}
+        onChange={() => setQuestionCount(number)}
+        checked={isActive}
+      />
+    </label>
   );
 };
 export default NumOfQBtn;

--- a/src/TriviaSetup.jsx
+++ b/src/TriviaSetup.jsx
@@ -5,6 +5,8 @@ const TriviaSetup = (props) => {
     props;
   const [inputVal, setInputVal] = useState("");
 
+  const QUESTION_COUNT_OPTIONS = [3, 5, 10];
+
   function startTrivia(userTopic, userNumOfQuestions) {
     console.log(userTopic);
     console.log(userNumOfQuestions);
@@ -33,9 +35,14 @@ const TriviaSetup = (props) => {
         <h2 className="font-extrabold text-xl">Step Two</h2>
         <p className="text-sm mb-1">How many questions should I include?</p>
         <div className="group flex justify-between gap-2">
-          <NumOfQBtn setQuestionCount={setQuestionCount} number={3} />
-          <NumOfQBtn setQuestionCount={setQuestionCount} number={5} />
-          <NumOfQBtn setQuestionCount={setQuestionCount} number={10} />
+        { 
+          QUESTION_COUNT_OPTIONS.map((number) => (
+            <NumOfQBtn 
+            key={number}
+            setQuestionCount={setQuestionCount} 
+            number={number}  />
+          ))
+        }
         </div>
         <button
           onClick={() => {

--- a/src/TriviaSetup.jsx
+++ b/src/TriviaSetup.jsx
@@ -38,9 +38,11 @@ const TriviaSetup = (props) => {
         { 
           QUESTION_COUNT_OPTIONS.map((number) => (
             <NumOfQBtn 
-            key={number}
-            setQuestionCount={setQuestionCount} 
-            number={number}  />
+              key={number}
+              setQuestionCount={setQuestionCount} 
+              number={number} 
+              isActive={number === questionCount} 
+            />
           ))
         }
         </div>


### PR DESCRIPTION
This PR addresses issue #1 and adds an active state to the NumOfQBtn component. 

I've set up a constant to hold the count options available to the user for improved reusability. 
The component was adjusted to be a label/radio button to apply active styling using Tailwinds `has` modifier. The `isActive` prop allows to check wether the input should initially be in the checked state.
